### PR TITLE
Fix the problem if cache is enabled

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -96,7 +96,7 @@
                     array(),
                     (int) $this->params->get('cache_time'),
                     array($this,'onDataError'),
-                    true
+                    false
                 );
             } else {
                 $data = $this->generate();


### PR DESCRIPTION
Hello, in helper.php in function display, the last parameter of $this->Cache function must be false and not true.
The $data parameter must be an array and not a json, so if the cache is enabled, with last parameter of the function Cache setted to true, Cache return a json instead an array and the templates not work properly.
